### PR TITLE
[feature] Rework git workflow process

### DIFF
--- a/.github/workflows/deploy-workflow.yml
+++ b/.github/workflows/deploy-workflow.yml
@@ -14,23 +14,24 @@ jobs:
       run:
         shell: bash
     steps:
-      - name: Checkout PyReindexer
+      - name: Checkout PyReindexer repo
         uses: actions/checkout@v4
-      - name: Install dependencies
-        run: |
-          sudo apt-get update -y
-          curl -L https://github.com/Restream/reindexer/raw/master/dependencies.sh | sudo bash -s
       - name: Checkout Reindexer repo
         uses: actions/checkout@v4
         with:
           repository: Restream/reindexer
           path: reindexer
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -y
+          cd reindexer
+          sudo bash dependencies.sh
       - name: Build Reindexer
         run: |
           cd reindexer
           mkdir -p build && cd build
           cmake ..
-          make -j8
+          make -j4
           sudo make install
       - name: Set up Python ${{ env.DEPLOY_BUILD_PYTHON_VERSION }}
         uses: actions/setup-python@v5
@@ -39,7 +40,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install build
+          python -m pip install build
       - name: Build PyReindexer
         run: python -m build --sdist
       - name: Store build artifacts
@@ -55,8 +56,6 @@ jobs:
     environment:
       name: pypi
       url: https://pypi.org/p/pyreindexer/
-    permissions:
-       id-token: write
     steps:
       - name: Fetch build artifacts
         uses: actions/download-artifact@v4
@@ -74,7 +73,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-20.04,ubuntu-22.04,ubuntu-24.04,macos-14]
+        os: [ubuntu-22.04,ubuntu-24.04,macos-14]
       fail-fast: false
     runs-on: ${{matrix.os}}
     env:
@@ -96,10 +95,13 @@ jobs:
         if: startsWith(matrix.os, 'ubuntu')
         run: |
           curl https://repo.reindexer.io/RX-KEY.GPG | sudo apt-key add
-          if [[ ${{matrix.os}} == ubuntu-20.04 ]]; then
-            echo 'deb https://repo.reindexer.io/ubuntu-focal /' | sudo tee -a /etc/apt/sources.list
-          else
+          if [[ ${{matrix.os}} == ubuntu-22.04 ]]; then
             echo 'deb https://repo.reindexer.io/ubuntu-jammy /' | sudo tee -a /etc/apt/sources.list
+          elif [[ ${{matrix.os}} == ubuntu-24.04 ]]; then
+            echo 'deb https://repo.reindexer.io/ubuntu-noble /' | sudo tee -a /etc/apt/sources.list
+          else
+            echo "${{matrix.os}} not supported"
+            exit 1
           fi
           sudo apt-get update -y
           sudo apt-get install -y libunwind-dev
@@ -113,7 +115,7 @@ jobs:
           python-version: ${{ env.BUILD_PYTHON_VERSION }}
       - name: Install PyReindexer
         run: |
-          python -m pip install --upgrade pip importlib_metadata setuptools wheel
+          python -m pip install --upgrade --disable-pip-version-check pip importlib_metadata setuptools wheel
           python -m pip install -vvv pyreindexer
       - name: Prepare Test Environment
         run: python -m pip install -r requirements.txt

--- a/.github/workflows/deploy-workflow.yml
+++ b/.github/workflows/deploy-workflow.yml
@@ -1,66 +1,102 @@
+name: Upload Release package
 on:
   push:
     branches:
       - master
+
 jobs:
-  deploy:
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Install Reindexer
-        run: |
-          brew tap restream/reindexer
-          brew install reindexer
+  build:
+    name: Build project (ubuntu)
+    runs-on: ubuntu-22.04
+    env:
+      DEPLOY_BUILD_PYTHON_VERSION: '3.12'
+    defaults:
+      run:
         shell: bash
+    steps:
+      - name: Checkout PyReindexer
+        uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -y
+          curl -L https://github.com/Restream/reindexer/raw/master/dependencies.sh | sudo bash -s
+      - name: Checkout Reindexer repo
+        uses: actions/checkout@v4
+        with:
+          repository: Restream/reindexer
+          path: reindexer
+      - name: Build Reindexer
+        run: |
+          cd reindexer
+          mkdir -p build && cd build
+          cmake ..
+          make -j8
+          sudo make install
+      - name: Set up Python ${{ env.DEPLOY_BUILD_PYTHON_VERSION }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.DEPLOY_BUILD_PYTHON_VERSION }}
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
       - name: Build PyReindexer
-        run: |
-          python3 -m pip install wheel
-          python3 setup.py sdist bdist_wheel
-        shell: bash
-      - name: Deploy PyReindexer To Pypi
-        env:
-          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-        run: |
-          python3 -m pip install twine
-          python3 -m twine upload --verbose dist/* -u __token__ -p pypi-$PYPI_TOKEN
-          # wait for deploy finnishing on test pypi server
-          sleep 240
-        shell: bash
+        run: python -m build --sdist
+      - name: Store build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: build
+          path: dist/*
 
-  test-macos:
-    runs-on: macos-latest
-    needs: deploy
+  deploy:
+    name: Upload to PyPI (ubuntu)
+    runs-on: ubuntu-22.04
+    needs: build
+    environment:
+      name: pypi
+      url: https://pypi.org/p/pyreindexer/
+    permissions:
+       id-token: write
     steps:
-      - uses: actions/checkout@v3
-      - name: Install Reindexer
-        run: |
-          brew tap restream/reindexer
-          brew install reindexer
-        shell: bash
-      - name: Install PyReindexer
-        run: python3 -m pip install -vvv pyreindexer
-        shell: bash
-      - name: Test
-        run: |
-          cd /Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/pyreindexer
-          $GITHUB_WORKSPACE/.github/workflows/test.sh
-        shell: bash
+      - name: Fetch build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build
+          path: dist/
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          verbose: true
+          # user: __token__ ## used as default
+          password: pypi-${{ secrets.PYPI_TOKEN }}
+          repository-url: https://pypi.org/legacy/
 
-  test-ubuntu:
+  test:
     strategy:
       matrix:
-        os: [ubuntu-20.04,ubuntu-22.04]
+        os: [ubuntu-20.04,ubuntu-22.04,ubuntu-24.04,macos-14]
       fail-fast: false
     runs-on: ${{matrix.os}}
     env:
-      OS: ${{matrix.os}}
+      # Python 3.12 issue found on MasOS arm64 (darwin) runners, actions/setup-python@v5 incorrect venv setup
+      BUILD_PYTHON_VERSION: ${{ startsWith(matrix.os, 'macos') && '3.8' || '3.12' }}
     needs: deploy
+    defaults:
+      run:
+        shell: bash
     steps:
-      - uses: actions/checkout@v3
-      - name: Install Reindexer-Dev
+      - name: Checkout PyReindexer
+        uses: actions/checkout@v4
+      - name: Install Reindexer (MacOS)
+        if: startsWith(matrix.os, 'macos')
+        run: |
+          brew tap restream/reindexer
+          brew install reindexer
+      - name: Install Reindexer-Dev\Server (Ubuntu)
+        if: startsWith(matrix.os, 'ubuntu')
         run: |
           curl https://repo.reindexer.io/RX-KEY.GPG | sudo apt-key add
-          if [[ $OS == ubuntu-20.04 ]]; then
+          if [[ ${{matrix.os}} == ubuntu-20.04 ]]; then
             echo 'deb https://repo.reindexer.io/ubuntu-focal /' | sudo tee -a /etc/apt/sources.list
           else
             echo 'deb https://repo.reindexer.io/ubuntu-jammy /' | sudo tee -a /etc/apt/sources.list
@@ -68,17 +104,20 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install -y libunwind-dev
           sudo apt-get install -y reindexer-dev
-        shell: bash
+          sudo apt-get install -y reindexer-server
+      - name: Set up Python ${{ env.BUILD_PYTHON_VERSION }}
+        uses: actions/setup-python@v5
+        env:
+          PIP_DISABLE_PIP_VERSION_CHECK: 1
+        with:
+          python-version: ${{ env.BUILD_PYTHON_VERSION }}
       - name: Install PyReindexer
         run: |
-          python3 -m pip install setuptools
-          python3 -m pip install -vvv pyreindexer
-        shell: bash
-      - name: Install Reindexer-Server
-        run: sudo apt-get install reindexer-server
-        shell: bash
+          python -m pip install --upgrade pip importlib_metadata setuptools wheel
+          python -m pip install -vvv pyreindexer
+      - name: Prepare Test Environment
+        run: python -m pip install -r requirements.txt
       - name: Test
         run: |
-          cd $(python3 -m site --user-site)/pyreindexer
+          cd $(python -c "import sysconfig; print(sysconfig.get_path('purelib'))")/pyreindexer
           $GITHUB_WORKSPACE/.github/workflows/test.sh
-        shell: bash

--- a/.github/workflows/test-deploy-workflow.yml
+++ b/.github/workflows/test-deploy-workflow.yml
@@ -13,23 +13,24 @@ jobs:
       run:
         shell: bash
     steps:
-      - name: Checkout PyReindexer
+      - name: Checkout PyReindexer repo
         uses: actions/checkout@v4
-      - name: Install dependencies
-        run: |
-          sudo apt-get update -y
-          curl -L https://github.com/Restream/reindexer/raw/master/dependencies.sh | sudo bash -s
       - name: Checkout Reindexer repo
         uses: actions/checkout@v4
         with:
           repository: Restream/reindexer
           path: reindexer
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -y
+          cd reindexer
+          sudo bash dependencies.sh
       - name: Build Reindexer
         run: |
           cd reindexer
           mkdir -p build && cd build
           cmake ..
-          make -j8
+          make -j4
           sudo make install
       - name: Set up Python ${{ env.DEPLOY_BUILD_PYTHON_VERSION }}
         uses: actions/setup-python@v5
@@ -38,7 +39,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install build
+          python -m pip install build
       - name: Build PyReindexer
         run: python -m build --sdist
       - name: Store build artifacts
@@ -54,8 +55,6 @@ jobs:
     environment:
       name: testpypi
       url: https://test.pypi.org/p/pyreindexer/
-    permissions:
-       id-token: write
     steps:
       - name: Fetch build artifacts
         uses: actions/download-artifact@v4
@@ -74,10 +73,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04,ubuntu-22.04,ubuntu-24.04,macos-14]
+        os: [ubuntu-22.04,ubuntu-24.04,macos-14]
     runs-on: ${{matrix.os}}
     env:
       # Python 3.12 issue found on MasOS arm64 (darwin) runners, actions/setup-python@v5 incorrect venv setup
+      # Error: The version '3.12' with architecture 'arm64' was not found for macOS 14.4. In real version 3.9+ not found
       # https://github.com/actions/setup-python/issues/654
       # https://github.com/actions/setup-python/issues/865
       BUILD_PYTHON_VERSION: ${{ startsWith(matrix.os, 'macos') && '3.8' || '3.12' }}
@@ -97,10 +97,13 @@ jobs:
         if: startsWith(matrix.os, 'ubuntu')
         run: |
           curl https://repo.reindexer.io/RX-KEY.GPG | sudo apt-key add
-          if [[ ${{matrix.os}} == ubuntu-20.04 ]]; then
-            echo 'deb https://repo.reindexer.io/ubuntu-focal /' | sudo tee -a /etc/apt/sources.list
-          else
+          if [[ ${{matrix.os}} == ubuntu-22.04 ]]; then
             echo 'deb https://repo.reindexer.io/ubuntu-jammy /' | sudo tee -a /etc/apt/sources.list
+          elif [[ ${{matrix.os}} == ubuntu-24.04 ]]; then
+            echo 'deb https://repo.reindexer.io/ubuntu-noble /' | sudo tee -a /etc/apt/sources.list
+          else
+            echo "${{matrix.os}} not supported"
+            exit 1
           fi
           sudo apt-get update -y
           sudo apt-get install -y libunwind-dev
@@ -114,7 +117,7 @@ jobs:
           python-version: ${{ env.BUILD_PYTHON_VERSION }}
       - name: Install PyReindexer
         run: |
-          python -m pip install --upgrade pip importlib_metadata setuptools wheel
+          python -m pip install --upgrade --disable-pip-version-check pip importlib_metadata setuptools wheel
           python -m pip install -vvv --index-url https://test.pypi.org/simple/ --no-deps pyreindexer
       - name: Prepare Test Environment
         run: python -m pip install -r requirements.txt

--- a/.github/workflows/test-deploy-workflow.yml
+++ b/.github/workflows/test-deploy-workflow.yml
@@ -1,65 +1,103 @@
+name: Upload Release package to TestPyPI
 on:
   pull_request:
     types: [opened, reopened]
+
 jobs:
-  deploy:
-    runs-on: macos-latest
-    steps:
-      - name: Install Reindexer
-        run: |
-          brew tap restream/reindexer
-          brew install reindexer
+  build:
+    name: Build project (ubuntu)
+    runs-on: ubuntu-22.04
+    env:
+      DEPLOY_BUILD_PYTHON_VERSION: '3.12'
+    defaults:
+      run:
         shell: bash
-      - uses: actions/checkout@v3
+    steps:
+      - name: Checkout PyReindexer
+        uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -y
+          curl -L https://github.com/Restream/reindexer/raw/master/dependencies.sh | sudo bash -s
+      - name: Checkout Reindexer repo
+        uses: actions/checkout@v4
+        with:
+          repository: Restream/reindexer
+          path: reindexer
+      - name: Build Reindexer
+        run: |
+          cd reindexer
+          mkdir -p build && cd build
+          cmake ..
+          make -j8
+          sudo make install
+      - name: Set up Python ${{ env.DEPLOY_BUILD_PYTHON_VERSION }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.DEPLOY_BUILD_PYTHON_VERSION }}
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
       - name: Build PyReindexer
-        run: python3 setup.py sdist bdist_wheel
-        shell: bash
-      - name: Deploy PyReindexer To Test-Pypi
-        env:
-          TESTPYPI_TOKEN: ${{ secrets.TESTPYPI_TOKEN }}
-        run: |
-          python3 -m pip install twine
-          python3 -m twine upload --verbose --repository testpypi dist/* -u __token__ -p pypi-$TESTPYPI_TOKEN
-          # wait for deploy finnishing on test pypi server
-          sleep 240
-        shell: bash
+        run: python -m build --sdist
+      - name: Store build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: build
+          path: dist/*
 
-  test-macos:
-    runs-on: macos-latest
-    needs: deploy
+  deploy:
+    name: Upload to TestPyPI (ubuntu)
+    runs-on: ubuntu-22.04
+    needs: build
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/pyreindexer/
+    permissions:
+       id-token: write
     steps:
-      - name: Install Reindexer
-        run: |
-          brew tap restream/reindexer
-          brew install reindexer
-        shell: bash
-      - uses: actions/checkout@v3
-      - name: Install PyReindexer
-        run: python3 -m pip install -vvv --index-url https://test.pypi.org/simple/ --no-deps pyreindexer
-        shell: bash
-      - name: Prepare Test Environment
-        run: python3 -m pip install pytest==6.2.5 delegator envoy pyhamcrest==2.0.2
-        shell: bash
-      - name: Test
-        run: |
-          cd /Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/pyreindexer
-          $GITHUB_WORKSPACE/.github/workflows/test.sh
-        shell: bash
+      - name: Fetch build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build
+          path: dist/
+      - name: Publish package distributions to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          verbose: true
+          # user: __token__ ## used as default
+          password: pypi-${{ secrets.TESTPYPI_TOKEN }}
+          repository-url: https://test.pypi.org/legacy/
 
-  test-ubuntu:
+  test:
     strategy:
-      matrix:
-        os: [ubuntu-20.04,ubuntu-22.04]
       fail-fast: false
+      matrix:
+        os: [ubuntu-20.04,ubuntu-22.04,ubuntu-24.04,macos-14]
     runs-on: ${{matrix.os}}
     env:
-      OS: ${{matrix.os}}
+      # Python 3.12 issue found on MasOS arm64 (darwin) runners, actions/setup-python@v5 incorrect venv setup
+      # https://github.com/actions/setup-python/issues/654
+      # https://github.com/actions/setup-python/issues/865
+      BUILD_PYTHON_VERSION: ${{ startsWith(matrix.os, 'macos') && '3.8' || '3.12' }}
     needs: deploy
+    defaults:
+      run:
+        shell: bash
     steps:
-      - name: Install Reindexer-Dev
+      - name: Checkout PyReindexer
+        uses: actions/checkout@v4
+      - name: Install Reindexer (MacOS)
+        if: startsWith(matrix.os, 'macos')
+        run: |
+          brew tap restream/reindexer
+          brew install reindexer
+      - name: Install Reindexer-Dev\Server (Ubuntu)
+        if: startsWith(matrix.os, 'ubuntu')
         run: |
           curl https://repo.reindexer.io/RX-KEY.GPG | sudo apt-key add
-          if [[ $OS == ubuntu-20.04 ]]; then
+          if [[ ${{matrix.os}} == ubuntu-20.04 ]]; then
             echo 'deb https://repo.reindexer.io/ubuntu-focal /' | sudo tee -a /etc/apt/sources.list
           else
             echo 'deb https://repo.reindexer.io/ubuntu-jammy /' | sudo tee -a /etc/apt/sources.list
@@ -67,21 +105,20 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install -y libunwind-dev
           sudo apt-get install -y reindexer-dev
-        shell: bash
-      - uses: actions/checkout@v3
+          sudo apt-get install -y reindexer-server
+      - name: Set up Python ${{ env.BUILD_PYTHON_VERSION }}
+        uses: actions/setup-python@v5
+        env:
+          PIP_DISABLE_PIP_VERSION_CHECK: 1
+        with:
+          python-version: ${{ env.BUILD_PYTHON_VERSION }}
       - name: Install PyReindexer
         run: |
-          python3 -m pip install setuptools
-          python3 -m pip install -vvv --index-url https://test.pypi.org/simple/ --no-deps pyreindexer
-        shell: bash
-      - name: Install Reindexer-Server
-        run: sudo apt-get install reindexer-server
-        shell: bash
+          python -m pip install --upgrade pip importlib_metadata setuptools wheel
+          python -m pip install -vvv --index-url https://test.pypi.org/simple/ --no-deps pyreindexer
       - name: Prepare Test Environment
-        run: python3 -m pip install pytest==6.2.5 delegator envoy pyhamcrest==2.0.2
-        shell: bash
+        run: python -m pip install -r requirements.txt
       - name: Test
         run: |
-          cd $(python3 -m site --user-site)/pyreindexer
+          cd $(python -c "import sysconfig; print(sysconfig.get_path('purelib'))")/pyreindexer
           $GITHUB_WORKSPACE/.github/workflows/test.sh
-        shell: bash

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -1,39 +1,34 @@
-on: 
+name: Test the project
+on:
   push:
     branches-ignore:
       - master
 jobs:
-  test-macos:
-    runs-on: macos-latest
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-20.04,ubuntu-22.04,ubuntu-24.04,macos-14]
+    runs-on: ${{matrix.os}}
+    env:
+      # Python 3.12 issue found on MasOS arm64 (darwin) runners, actions/setup-python@v5 incorrect venv setup
+      BUILD_PYTHON_VERSION: ${{ startsWith(matrix.os, 'macos') && '3.8' || '3.12' }}
+    defaults:
+      run:
+        shell: bash
     steps:
-      - name: Install Reindexer
+      - name: Checkout PyReindexer
+        uses: actions/checkout@v4
+      - name: Install Reindexer-Dev\Server (MacOS)
+        if: startsWith(matrix.os, 'macos')
         run: |
           brew tap restream/reindexer
           brew install reindexer
-        shell: bash
-      - uses: actions/checkout@v3
-      - name: Build PyReindexer
-        run: python3 setup.py install
-        shell: bash
-      - name: Test
-        run: |
-          cd pyreindexer
-          $GITHUB_WORKSPACE/.github/workflows/test.sh
-        shell: bash
-
-  test-ubuntu:
-    strategy:
-      matrix:
-        os: [ubuntu-20.04,ubuntu-22.04]
-      fail-fast: false
-    runs-on: ${{matrix.os}}
-    env:
-      OS: ${{matrix.os}}
-    steps:
-      - name: Install Reindexer-Dev
+      - name: Install Reindexer-Dev\Server (Ubuntu)
+        if: startsWith(matrix.os, 'ubuntu')
         run: |
           curl https://repo.reindexer.io/RX-KEY.GPG | sudo apt-key add
-          if [[ $OS == ubuntu-20.04 ]]; then
+          if [[ ${{matrix.os}} == ubuntu-20.04 ]]; then
             echo 'deb https://repo.reindexer.io/ubuntu-focal /' | sudo tee -a /etc/apt/sources.list
           else
             echo 'deb https://repo.reindexer.io/ubuntu-jammy /' | sudo tee -a /etc/apt/sources.list
@@ -41,19 +36,23 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install -y libunwind-dev
           sudo apt-get install -y reindexer-dev
-        shell: bash
-      - uses: actions/checkout@v3
+          sudo apt-get install -y reindexer-server
+      - name: Set up Python ${{ env.BUILD_PYTHON_VERSION }}
+        uses: actions/setup-python@v5
+        env:
+          PIP_DISABLE_PIP_VERSION_CHECK: 1
+        with:
+          python-version: ${{ env.BUILD_PYTHON_VERSION }}
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools build
+      - name: Prepare Test Environment
+        run: python -m pip install -r requirements.txt
       - name: Build PyReindexer
         run: |
-          python3 -m pip install setuptools
-          python3 setup.py build
-          sudo python3 setup.py install
-        shell: bash
-      - name: Install Reindexer-Server
-        run: sudo apt-get install reindexer-server
-        shell: bash
+          python -m build
+          pip install .
       - name: Test
         run: |
           cd pyreindexer
           $GITHUB_WORKSPACE/.github/workflows/test.sh
-        shell: bash

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04,ubuntu-22.04,ubuntu-24.04,macos-14]
+        os: [ubuntu-22.04,ubuntu-24.04,macos-14]
     runs-on: ${{matrix.os}}
     env:
       # Python 3.12 issue found on MasOS arm64 (darwin) runners, actions/setup-python@v5 incorrect venv setup
@@ -17,7 +17,7 @@ jobs:
       run:
         shell: bash
     steps:
-      - name: Checkout PyReindexer
+      - name: Checkout PyReindexer repo
         uses: actions/checkout@v4
       - name: Install Reindexer-Dev\Server (MacOS)
         if: startsWith(matrix.os, 'macos')
@@ -28,10 +28,13 @@ jobs:
         if: startsWith(matrix.os, 'ubuntu')
         run: |
           curl https://repo.reindexer.io/RX-KEY.GPG | sudo apt-key add
-          if [[ ${{matrix.os}} == ubuntu-20.04 ]]; then
-            echo 'deb https://repo.reindexer.io/ubuntu-focal /' | sudo tee -a /etc/apt/sources.list
-          else
+          if [[ ${{matrix.os}} == ubuntu-22.04 ]]; then
             echo 'deb https://repo.reindexer.io/ubuntu-jammy /' | sudo tee -a /etc/apt/sources.list
+          elif [[ ${{matrix.os}} == ubuntu-24.04 ]]; then
+            echo 'deb https://repo.reindexer.io/ubuntu-noble /' | sudo tee -a /etc/apt/sources.list
+          else
+            echo "${{matrix.os}} not supported"
+            exit 1
           fi
           sudo apt-get update -y
           sudo apt-get install -y libunwind-dev
@@ -45,13 +48,13 @@ jobs:
           python-version: ${{ env.BUILD_PYTHON_VERSION }}
       - name: Install Python dependencies
         run: |
-          python -m pip install --upgrade pip setuptools build
+          python -m pip install --upgrade --disable-pip-version-check pip setuptools build
       - name: Prepare Test Environment
         run: python -m pip install -r requirements.txt
       - name: Build PyReindexer
         run: |
           python -m build
-          pip install .
+          python -m pip install .
       - name: Test
         run: |
           cd pyreindexer


### PR DESCRIPTION
- replace builder & deploy platform - now **ubuntu-22.04** (before **_macos_**)
- build in venv (actions/setup-python@v5)
- add support _ubuntu-24.04 (Python 3.12)_, now list is: [**ubuntu-20.04,ubuntu-22.04,ubuntu-24.04,macos-14**]
- fix MacOS test (**_macos-14 Python 3.8_**). Couldn't find a way to run in a virtual environment Python 3.12 on MacOS-14 with arm64 (darwin). Without venv worked on runner [MacOS-14 with Phyton 3.12.5](https://github.com/actions/runner-images/blob/main/images/macos/macos-14-arm64-Readme.md)

[list of available runners](https://github.com/actions/runner-images/tree/main)