### PR TITLE
[fix] gason::JSON_EMPTY as part of JsonTag enum

### DIFF
--- a/pyreindexer/lib/include/pyobjtools.cc
+++ b/pyreindexer/lib/include/pyobjtools.cc
@@ -157,6 +157,9 @@ PyObject* pyValueFromJsonValue(const gason::JsonValue& value) {
 				Py_XDECREF(dictFromJson);
 			}
 			break;
+		case gason::JSON_EMPTY:
+			throw gason::Exception("Unexpected `JSON_EMPTY` tag");
+			break;
 	}
 
 	return pyValue;

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ class BuildExt(build_ext_orig):
 
 
 setup(name=PACKAGE_NAME,
-      version='0.2.42',
+      version='0.2.43',
       description='A connector that allows to interact with Reindexer',
       author='Igor Tulmentyev',
       author_email='igtulm@gmail.com',


### PR DESCRIPTION
Maintaining a project in a coherent state.
In Reindexer JsonTag enum updated.