### PR TITLE
fix __del__ methods

### DIFF
--- a/pyreindexer/query.py
+++ b/pyreindexer/query.py
@@ -89,13 +89,14 @@ class Query:
         self.join_queries: list[Query] = []
         self.merged_queries: list[Query] = []
 
-    def _del(self):
+    def __del__(self):
         """Frees query memory
 
         """
 
         if self.query_wrapper_ptr > 0:
             self.api.destroy_query(self.query_wrapper_ptr)
+            self.query_wrapper_ptr = 0
 
     def __raise_on_error(self) -> None:
         """Checks if there is an error code and raises with an error message

--- a/pyreindexer/query.py
+++ b/pyreindexer/query.py
@@ -6,10 +6,11 @@ from enum import Enum
 from typing import List, Optional, Union
 from uuid import UUID
 
-from pyreindexer.exceptions import ApiError, QueryError
+from pyreindexer.exceptions import QueryError
 from pyreindexer.index_search_params import IndexSearchParamBruteForce, IndexSearchParamHnsw, IndexSearchParamIvf
 from pyreindexer.point import Point
 from pyreindexer.query_results import QueryResults
+from raiser_mixin import RaiserQuery
 
 
 class ExtendedEnum(Enum):
@@ -58,7 +59,7 @@ class LogLevel(ExtendedEnum):
 simple_types = Union[int, str, bool, float]
 
 
-class Query:
+class Query(RaiserQuery):
     """An object representing the context of a Reindexer query
 
     #### Attributes:
@@ -72,7 +73,7 @@ class Query:
 
     """
 
-    def __init__(self, api, query_wrapper_ptr: int):
+    def __init__(self, rx, query_wrapper_ptr: int):
         """Constructs a new Reindexer query object
 
         #### Arguments:
@@ -81,7 +82,8 @@ class Query:
 
         """
 
-        self.api = api
+        self.rx = rx
+        self.api = rx.api
         self.query_wrapper_ptr: int = query_wrapper_ptr
         self.err_code: int = 0
         self.err_msg: str = ''
@@ -94,23 +96,13 @@ class Query:
 
         """
 
-        if self.query_wrapper_ptr > 0:
+        if self.query_wrapper_ptr > 0 and self.rx.rx > 0:
             self.api.destroy_query(self.query_wrapper_ptr)
+            self.rx.query_ptrs.remove(self.query_wrapper_ptr)
             self.query_wrapper_ptr = 0
 
-    def __raise_on_error(self) -> None:
-        """Checks if there is an error code and raises with an error message
-
-        #### Raises:
-            ApiError: Raises with an error message of API return on non-zero error code
-
-        """
-
-        if self.err_code:
-            raise ApiError(self.err_msg)
-
     @staticmethod
-    def __where_knn_param(param: Union[IndexSearchParamBruteForce|IndexSearchParamHnsw|IndexSearchParamIvf]):
+    def __where_knn_param(param: Union[IndexSearchParamBruteForce | IndexSearchParamHnsw | IndexSearchParamIvf]):
         """Validate and convert KNN search parameters
 
         #### Arguments:
@@ -208,6 +200,7 @@ class Query:
 
         return [] if param is None else list(param)
 
+    @RaiserQuery.raise_if_error
     def __where(self, index: str, condition: CondType,
                 keys: Union[simple_types, tuple[list[simple_types], ...]]) -> Query:
         """Adds where condition to DB query with args
@@ -234,7 +227,6 @@ class Query:
         params = self.__convert_to_list(keys)
 
         self.err_code, self.err_msg = self.api.where(self.query_wrapper_ptr, index, condition.value, params)
-        self.__raise_on_error()
         return self
 
     def where(self, index: str, condition: CondType,
@@ -258,6 +250,7 @@ class Query:
 
         return self.__where(index, condition, keys)
 
+    @RaiserQuery.raise_if_error
     def where_query(self, sub_query: Query, condition: CondType,
                     keys: Union[simple_types, tuple[list[simple_types], ...]] = None) -> Query:
         """Adds sub-query where condition to DB query with args
@@ -279,11 +272,12 @@ class Query:
 
         params = self.__convert_to_list(keys)
 
-        self.err_code, self.err_msg = self.api.where_subquery(self.query_wrapper_ptr, sub_query.query_wrapper_ptr,
+        self.err_code, self.err_msg = self.api.where_subquery(self.query_wrapper_ptr,
+                                                              sub_query.query_wrapper_ptr,
                                                               condition.value, params)
-        self.__raise_on_error()
         return self
 
+    @RaiserQuery.raise_if_error
     def where_subquery(self, index: str, condition: CondType, sub_query: Query) -> Query:
         """Adds sub-query where condition to DB query
 
@@ -297,7 +291,8 @@ class Query:
 
         """
 
-        self.api.where_field_subquery(self.query_wrapper_ptr, index, condition.value, sub_query.query_wrapper_ptr)
+        self.api.where_field_subquery(self.query_wrapper_ptr, index, condition.value,
+                                      sub_query.query_wrapper_ptr)
         return self
 
     def where_composite(self, index: str, condition: CondType, keys: tuple[list[simple_types], ...]) -> Query:
@@ -324,6 +319,7 @@ class Query:
 
         return self.__where(index, condition, keys)
 
+    @RaiserQuery.raise_if_error
     def where_uuid(self, index: str, condition: CondType, *uuids: UUID) -> Query:
         """Adds where condition to DB query with UUID.
             `index` MUST be declared as uuid-string index in this case
@@ -346,10 +342,11 @@ class Query:
         for item in uuids:
             params.append(str(item))
 
-        self.err_code, self.err_msg = self.api.where_uuid(self.query_wrapper_ptr, index, condition.value, params)
-        self.__raise_on_error()
+        self.err_code, self.err_msg = self.api.where_uuid(self.query_wrapper_ptr, index, condition.value,
+                                                          params)
         return self
 
+    @RaiserQuery.raise_if_error
     def where_between_fields(self, first_field: str, condition: CondType, second_field: str) -> Query:
         """Adds comparing two fields where condition to DB query
 
@@ -366,8 +363,9 @@ class Query:
         self.api.where_between_fields(self.query_wrapper_ptr, first_field, condition.value, second_field)
         return self
 
+    @RaiserQuery.raise_if_error
     def where_knn(self, index: str, vec: List[float],
-                  param: Union[IndexSearchParamBruteForce|IndexSearchParamHnsw|IndexSearchParamIvf]) -> Query:
+                  param: Union[IndexSearchParamBruteForce | IndexSearchParamHnsw | IndexSearchParamIvf]) -> Query:
         """Adds where condition to DB query with float_vector as args.
             `index` MUST be declared as float_vector index in this case
 
@@ -392,13 +390,14 @@ class Query:
 
         k, is_k, radius, is_radius, ef, nprobe = self.__where_knn_param(param)
 
-        self.err_code, self.err_msg =\
-            self.api.where_knn(self.query_wrapper_ptr, index, is_k, k, is_radius, radius, ef, nprobe, vec)
-        self.__raise_on_error()
+        self.err_code, self.err_msg = self.api.where_knn(self.query_wrapper_ptr, index, is_k, k,
+                                                         is_radius, radius, ef, nprobe, vec)
         return self
 
+    @RaiserQuery.raise_if_error
     def where_knn_string(self, index: str, value: str,
-                         param: Union[IndexSearchParamBruteForce|IndexSearchParamHnsw|IndexSearchParamIvf]) -> Query:
+                         param: Union[
+                             IndexSearchParamBruteForce | IndexSearchParamHnsw | IndexSearchParamIvf]) -> Query:
         """Adds where condition to DB query with string as args.
             `index` MUST be declared as float_vector index in this case.
             WARNING: Only relevant if automatic embedding is configured for this float_vector index
@@ -424,11 +423,11 @@ class Query:
 
         k, is_k, radius, is_radius, ef, nprobe = self.__where_knn_param(param)
 
-        self.err_code, self.err_msg =\
-            self.api.where_knn_string(self.query_wrapper_ptr, index, is_k, k, is_radius, radius, ef, nprobe, value)
-        self.__raise_on_error()
+        self.err_code, self.err_msg = self.api.where_knn_string(self.query_wrapper_ptr, index, is_k, k,
+                                                                is_radius, radius, ef, nprobe, value)
         return self
 
+    @RaiserQuery.raise_if_error
     def open_bracket(self) -> Query:
         """Opens bracket for where condition to DB query
 
@@ -441,9 +440,9 @@ class Query:
         """
 
         self.err_code, self.err_msg = self.api.open_bracket(self.query_wrapper_ptr)
-        self.__raise_on_error()
         return self
 
+    @RaiserQuery.raise_if_error
     def close_bracket(self) -> Query:
         """Closes bracket for where condition to DB query
 
@@ -456,9 +455,9 @@ class Query:
         """
 
         self.err_code, self.err_msg = self.api.close_bracket(self.query_wrapper_ptr)
-        self.__raise_on_error()
         return self
 
+    @RaiserQuery.raise_if_error
     def match(self, index: str, *keys: str) -> Query:
         """Adds string EQ-condition to DB query with string args
 
@@ -477,10 +476,11 @@ class Query:
 
         params: list = self.__convert_strs_to_list(keys)
 
-        self.err_code, self.err_msg = self.api.where(self.query_wrapper_ptr, index, CondType.CondEq.value, params)
-        self.__raise_on_error()
+        self.err_code, self.err_msg = self.api.where(self.query_wrapper_ptr, index, CondType.CondEq.value,
+                                                     params)
         return self
 
+    @RaiserQuery.raise_if_error
     def dwithin(self, index: str, point: Point, distance: float) -> Query:
         """Adds DWithin condition to DB query
 
@@ -497,6 +497,7 @@ class Query:
         self.api.dwithin(self.query_wrapper_ptr, index, point.x, point.y, distance)
         return self
 
+    @RaiserQuery.raise_if_error
     def distinct(self, index: str) -> Query:
         """Performs distinct for a certain index. Return only items with uniq value of field
 
@@ -511,6 +512,7 @@ class Query:
         self.api.aggregate_distinct(self.query_wrapper_ptr, index)
         return self
 
+    @RaiserQuery.raise_if_error
     def aggregate_sum(self, index: str) -> Query:
         """Performs a summation of values for a specified index
 
@@ -525,6 +527,7 @@ class Query:
         self.api.aggregate_sum(self.query_wrapper_ptr, index)
         return self
 
+    @RaiserQuery.raise_if_error
     def aggregate_avg(self, index: str) -> Query:
         """Finds for the average at the specified index
 
@@ -539,6 +542,7 @@ class Query:
         self.api.aggregate_avg(self.query_wrapper_ptr, index)
         return self
 
+    @RaiserQuery.raise_if_error
     def aggregate_min(self, index: str) -> Query:
         """Finds for the minimum at the specified index
 
@@ -553,6 +557,7 @@ class Query:
         self.api.aggregate_min(self.query_wrapper_ptr, index)
         return self
 
+    @RaiserQuery.raise_if_error
     def aggregate_max(self, index: str) -> Query:
         """Finds for the maximum at the specified index
 
@@ -567,7 +572,7 @@ class Query:
         self.api.aggregate_max(self.query_wrapper_ptr, index)
         return self
 
-    class _AggregateFacet:
+    class _AggregateFacet(RaiserQuery):
         """An object representing the context of a Reindexer aggregate facet
 
         #### Attributes:
@@ -584,6 +589,7 @@ class Query:
 
             """
 
+            self.rx = query.rx
             self.api = query.api
             self.query_wrapper_ptr = query.query_wrapper_ptr
 
@@ -630,6 +636,7 @@ class Query:
             self.api.aggregation_sort(self.query_wrapper_ptr, field, desc)
             return self
 
+    @RaiserQuery.raise_if_error
     def aggregate_facet(self, *fields: str) -> Query._AggregateFacet:
         """Gets fields facet value. Applicable to multiple data fields and the result of that could be sorted
             by any data column or `count` and cut off by offset and limit. In order to support this functionality
@@ -646,9 +653,9 @@ class Query:
         params: list = self.__convert_strs_to_list(fields)
 
         self.err_code, self.err_msg = self.api.aggregation(self.query_wrapper_ptr, params)
-        self.__raise_on_error()
         return self._AggregateFacet(self)
 
+    @RaiserQuery.raise_if_error
     def sort(self, index: str, desc: bool = False,
              forced_sort_values: Union[simple_types, tuple[list[simple_types], ...]] = None) -> Query:
         """Applies sort order to return from query items. If forced_sort_values argument specified, then items equal to
@@ -672,7 +679,6 @@ class Query:
         values = self.__convert_to_list(forced_sort_values)
 
         self.err_code, self.err_msg = self.api.sort(self.query_wrapper_ptr, index, desc, values)
-        self.__raise_on_error()
         return self
 
     def sort_stpoint_distance(self, index: str, point: Point, desc: bool) -> Query:
@@ -712,6 +718,7 @@ class Query:
         request: str = f"ST_Distance({first_field},{second_field})"
         return self.sort(request, desc)
 
+    @RaiserQuery.raise_if_error
     def op_and(self) -> Query:
         """Next condition will be added with AND.
             This is the default operation for WHERE statement. Do not have to be called explicitly in user's code.
@@ -725,6 +732,7 @@ class Query:
         self.api.op_and(self.query_wrapper_ptr)
         return self
 
+    @RaiserQuery.raise_if_error
     def op_or(self) -> Query:
         """Next condition will be added with OR.
             Implements short-circuiting:
@@ -738,6 +746,7 @@ class Query:
         self.api.op_or(self.query_wrapper_ptr)
         return self
 
+    @RaiserQuery.raise_if_error
     def op_not(self) -> Query:
         """Next condition will be added with NOT AND.
             Implements short-circuiting: if the previous condition is failed the next will not be evaluated
@@ -750,6 +759,7 @@ class Query:
         self.api.op_not(self.query_wrapper_ptr)
         return self
 
+    @RaiserQuery.raise_if_error
     def request_total(self) -> Query:
         """Requests total items calculation
 
@@ -764,6 +774,7 @@ class Query:
         self.api.request_total(self.query_wrapper_ptr)
         return self
 
+    @RaiserQuery.raise_if_error
     def cached_total(self) -> Query:
         """Requests cached total items calculation
 
@@ -778,6 +789,7 @@ class Query:
         self.api.cached_total(self.query_wrapper_ptr)
         return self
 
+    @RaiserQuery.raise_if_error
     def limit(self, limit_items: int) -> Query:
         """Sets a limit (count) of returned items. Analog to sql LIMIT rowsNumber
 
@@ -792,6 +804,7 @@ class Query:
         self.api.limit(self.query_wrapper_ptr, limit_items)
         return self
 
+    @RaiserQuery.raise_if_error
     def offset(self, start_offset: int) -> Query:
         """Sets the number of the first selected row from result query
 
@@ -806,6 +819,7 @@ class Query:
         self.api.offset(self.query_wrapper_ptr, start_offset)
         return self
 
+    @RaiserQuery.raise_if_error
     def debug(self, level: LogLevel) -> Query:
         """Changes debug log level on server
 
@@ -820,6 +834,7 @@ class Query:
         self.api.debug(self.query_wrapper_ptr, level.value)
         return self
 
+    @RaiserQuery.raise_if_error
     def strict(self, mode: StrictMode) -> Query:
         """Changes strict mode
 
@@ -834,6 +849,7 @@ class Query:
         self.api.strict(self.query_wrapper_ptr, mode.value)
         return self
 
+    @RaiserQuery.raise_if_error
     def explain(self) -> Query:
         """Enables explain query
 
@@ -845,6 +861,7 @@ class Query:
         self.api.explain(self.query_wrapper_ptr)
         return self
 
+    @RaiserQuery.raise_if_error
     def with_rank(self) -> Query:
         """Outputs fulltext/float_vector rank. Allowed only with fulltext and KNN query
 
@@ -856,6 +873,7 @@ class Query:
         self.api.with_rank(self.query_wrapper_ptr)
         return self
 
+    @RaiserQuery.raise_if_error
     def execute(self, timeout: timedelta = timedelta(milliseconds=0)) -> QueryResults:
         """Executes a select query
 
@@ -877,11 +895,11 @@ class Query:
             return self.root.execute(timeout)
 
         milliseconds: int = int(timeout / timedelta(milliseconds=1))
-        (self.err_code, self.err_msg,
-         wrapper_ptr, iter_count, total_count) = self.api.select_query(self.query_wrapper_ptr, milliseconds)
-        self.__raise_on_error()
+        self.err_code, self.err_msg, wrapper_ptr, iter_count, total_count = self.api.select_query(
+            self.query_wrapper_ptr, milliseconds)
         return QueryResults(self.api, wrapper_ptr, iter_count, total_count)
 
+    @RaiserQuery.raise_if_error
     def delete(self, timeout: timedelta = timedelta(milliseconds=0)) -> int:
         """Executes a query, and delete items, matches query
 
@@ -904,9 +922,9 @@ class Query:
 
         milliseconds: int = int(timeout / timedelta(milliseconds=1))
         self.err_code, self.err_msg, number = self.api.delete_query(self.query_wrapper_ptr, milliseconds)
-        self.__raise_on_error()
         return number
 
+    @RaiserQuery.raise_if_error
     def set_object(self, field: str, values: list[simple_types]) -> Query:
         """Adds an update query to an object field for an update query
 
@@ -927,9 +945,9 @@ class Query:
             raise QueryError("A required parameter is not specified. `values` can't be None")
 
         self.err_code, self.err_msg = self.api.set_object(self.query_wrapper_ptr, field, values)
-        self.__raise_on_error()
         return self
 
+    @RaiserQuery.raise_if_error
     def set(self, field: str, values: list[simple_types]) -> Query:
         """Adds a field update request to the update request
 
@@ -948,9 +966,9 @@ class Query:
         values = [] if values is None else values
 
         self.err_code, self.err_msg = self.api.set(self.query_wrapper_ptr, field, values)
-        self.__raise_on_error()
         return self
 
+    @RaiserQuery.raise_if_error
     def drop(self, index: str) -> Query:
         """Drops a value for a field
 
@@ -965,6 +983,7 @@ class Query:
         self.api.drop(self.query_wrapper_ptr, index)
         return self
 
+    @RaiserQuery.raise_if_error
     def expression(self, field: str, value: str) -> Query:
         """Updates indexed field by arithmetical expression
 
@@ -980,6 +999,7 @@ class Query:
         self.api.expression(self.query_wrapper_ptr, field, value)
         return self
 
+    @RaiserQuery.raise_if_error
     def update(self, timeout: timedelta = timedelta(milliseconds=0)) -> QueryResults:
         """Executes update query, and update fields in items, which matches query
 
@@ -1001,11 +1021,11 @@ class Query:
             raise QueryError("Update does not support joined queries")
 
         milliseconds: int = int(timeout / timedelta(milliseconds=1))
-        (self.err_code, self.err_msg,
-         wrapper_ptr, iter_count, total_count) = self.api.update_query(self.query_wrapper_ptr, milliseconds)
-        self.__raise_on_error()
+        self.err_code, self.err_msg, wrapper_ptr, iter_count, total_count = self.api.update_query(
+            self.query_wrapper_ptr, milliseconds)
         return QueryResults(self.api, wrapper_ptr, iter_count, total_count)
 
+    @RaiserQuery.raise_if_error
     def must_execute(self, timeout: timedelta = timedelta(milliseconds=0)) -> QueryResults:
         """Executes a query, and update fields in items, which matches query, with status check
 
@@ -1027,6 +1047,7 @@ class Query:
         result.status()
         return result
 
+    @RaiserQuery.raise_if_error
     def get(self, timeout: timedelta = timedelta(milliseconds=0)) -> (str, bool):
         """Executes a query, and return 1 JSON item
 
@@ -1053,6 +1074,7 @@ class Query:
 
         return '', False
 
+    @RaiserQuery.raise_if_error
     def __join(self, query: Query, field: str, join_type: JoinType) -> Query:
         """Joins queries
 
@@ -1131,6 +1153,7 @@ class Query:
 
         return self.__join(join_query, field, JoinType.LeftJoin)
 
+    @RaiserQuery.raise_if_error
     def merge(self, query: Query) -> Query:
         """Merges queries of the same type
 
@@ -1153,6 +1176,7 @@ class Query:
         self.api.merge(self.query_wrapper_ptr, query.query_wrapper_ptr)
         return self
 
+    @RaiserQuery.raise_if_error
     def on(self, index: str, condition: CondType, join_index: str) -> Query:
         """On specifies join condition
 
@@ -1175,6 +1199,7 @@ class Query:
         self.api.on(self.query_wrapper_ptr, index, condition.value, join_index)
         return self
 
+    @RaiserQuery.raise_if_error
     def select_fields(self, *fields: str) -> Query:
         """Sets list of columns in this namespace to be finally selected.
             The columns should be specified in the same case as the jsonpaths corresponding to them.
@@ -1195,9 +1220,9 @@ class Query:
         keys: list = self.__convert_strs_to_list(fields)
 
         self.err_code, self.err_msg = self.api.select_fields(self.query_wrapper_ptr, keys)
-        self.__raise_on_error()
         return self
 
+    @RaiserQuery.raise_if_error
     def functions(self, *functions: str) -> Query:
         """Adds sql-functions to query
 
@@ -1215,9 +1240,9 @@ class Query:
         funcs: list = self.__convert_strs_to_list(functions)
 
         self.err_code, self.err_msg = self.api.functions(self.query_wrapper_ptr, funcs)
-        self.__raise_on_error()
         return self
 
+    @RaiserQuery.raise_if_error
     def equal_position(self, *equal_position: str) -> Query:
         """Adds equal position fields to arrays queries
 
@@ -1235,5 +1260,4 @@ class Query:
         equal_pos: list = self.__convert_strs_to_list(equal_position)
 
         self.err_code, self.err_msg = self.api.equal_position(self.query_wrapper_ptr, equal_pos)
-        self.__raise_on_error()
         return self

--- a/pyreindexer/query.py
+++ b/pyreindexer/query.py
@@ -89,7 +89,7 @@ class Query:
         self.join_queries: list[Query] = []
         self.merged_queries: list[Query] = []
 
-    def __del__(self):
+    def _del(self):
         """Frees query memory
 
         """

--- a/pyreindexer/query.py
+++ b/pyreindexer/query.py
@@ -97,8 +97,9 @@ class Query(RaiserQuery):
         """
 
         if self.query_wrapper_ptr > 0 and self.rx.rx > 0:
+            with self.rx._query_lock:
+                self.rx._query_ptrs.remove(self.query_wrapper_ptr)
             self.api.destroy_query(self.query_wrapper_ptr)
-            self.rx.query_ptrs.remove(self.query_wrapper_ptr)
             self.query_wrapper_ptr = 0
 
     @staticmethod

--- a/pyreindexer/raiser_mixin.py
+++ b/pyreindexer/raiser_mixin.py
@@ -1,13 +1,23 @@
-from pyreindexer.exceptions import ApiError
+from pyreindexer.exceptions import ApiError, TransactionError
 
 
-class RaiserMixin:
-    """RaiserMixin contains methods for checking some typical API bad events and raise if there is a necessity
+class RaiserRx:
+    """Contains methods for checking some typical API bad events and raise if there is a necessity
 
     """
     err_code: int
     err_msg: str
     rx: int
+
+    @staticmethod
+    def raise_if_error(func):
+        def wrapper(self, *args, **kwargs):
+            self.raise_on_not_init()
+            res = func(self, *args, **kwargs)
+            self.raise_on_error()
+            return res
+
+        return wrapper
 
     def raise_on_error(self):
         """Checks if there is an error code and raises with an error message
@@ -29,14 +39,51 @@ class RaiserMixin:
         """
 
         if self.rx <= 0:
-            raise ConnectionError("Connection is not initialized")
+            raise ConnectionError("Connection is not initialized: reindexer C-binding object does not exist")
 
 
-def raise_if_error(func):
-    def wrapper(self, *args, **kwargs):
-        self.raise_on_not_init()
-        res = func(self, *args, **kwargs)
-        self.raise_on_error()
-        return res
+class RaiserQuery(RaiserRx):
+    """Contains methods for checking some typical API bad events and raise if there is a necessity
 
-    return wrapper
+    """
+    rx: None
+
+    def raise_on_not_init(self):
+        """Checks if there is an error code and raises with an error message
+
+        #### Raises:
+            ConnectionError: Raises with an error message when Reindexer instance is not initialized yet
+
+        """
+
+        if self.rx.rx <= 0:
+            raise ConnectionError("Connection is not initialized: reindexer C-binding object does not exist")
+
+
+class RaiserTx(RaiserQuery):
+    """Contains methods for checking some typical API bad events and raise if there is a necessity
+
+    """
+    transaction_wrapper_ptr: int
+
+    @staticmethod
+    def raise_if_error(func):
+        def wrapper(self, *args, **kwargs):
+            self.raise_on_not_init()
+            self.raise_on_is_over()
+            res = func(self, *args, **kwargs)
+            self.raise_on_error()
+            return res
+
+        return wrapper
+
+    def raise_on_is_over(self):
+        """Checks if there is an error code and raises with an error message
+
+        #### Raises:
+            ApiError: Raises with an error message of API return on non-zero error code
+
+        """
+
+        if self.transaction_wrapper_ptr <= 0:
+            raise TransactionError("Transaction is over")

--- a/pyreindexer/rx_connector.py
+++ b/pyreindexer/rx_connector.py
@@ -106,7 +106,7 @@ class RxConnector(RaiserMixin):
 
         if self.rx > 0:
             for obj in self.rx_objects:
-                obj._del()
+                obj.__del__()
             self._api_close()
 
     def close(self) -> None:

--- a/pyreindexer/rx_connector.py
+++ b/pyreindexer/rx_connector.py
@@ -97,6 +97,7 @@ class RxConnector(RaiserMixin):
                                 start_special_thread, client_name, sync_rxcoro_count,
                                 max_replication_updates_size, allocator_cache_limit, allocator_cache_part)
         self._api_connect(dsn, net_timeout)
+        self.rx_objects = []
 
     def __del__(self):
         """Closes an API instance on a connector object deletion if the API is initialized
@@ -104,58 +105,9 @@ class RxConnector(RaiserMixin):
         """
 
         if self.rx > 0:
-            print("RX")
+            for obj in self.rx_objects:
+                obj.__del__()
             self._api_close()
-
-    def _api_import(self, dsn: str) -> None:
-        """Imports an API dynamically depending on protocol specified in dsn
-
-        #### Arguments:
-            dsn (string): The connection string which contains a protocol
-
-        #### Raises:
-            ConnectionError: Raises an exception if a connection protocol is unrecognized
-
-        """
-
-        if dsn.startswith('builtin://'):
-            self.api = __import__('rawpyreindexerb')
-        elif dsn.startswith('cproto://'):
-            self.api = __import__('rawpyreindexerc')
-        else:
-            raise ConnectionError(f"Unknown Reindexer connection protocol for dsn: {dsn}")
-
-    def _api_connect(self, dsn: str, timeout: timedelta) -> None:
-        """Connects to a database specified in dsn. Obtains a pointer to Reindexer instance
-
-        #### Arguments:
-            dsn (string): The connection string which contains a protocol
-            timeout (`datetime.timedelta`): Optional timeout for performing a server-side operation.
-                Minimum is 1 millisecond; if set to a lower value, it corresponds to disabling the timeout.
-                A value of 0 disables the timeout (default value)
-
-        #### Raises:
-            ConnectionError: Raises with an error message when Reindexer instance is not initialized yet
-            ApiError: Raises with an error message of API return on non-zero error code
-
-        """
-
-        self.raise_on_not_init()
-        milliseconds: int = int(timeout / timedelta(milliseconds=1))
-        self.err_code, self.err_msg = self.api.connect(self.rx, dsn, milliseconds)
-        self.raise_on_error()
-
-    def _api_close(self) -> None:
-        """Destructs Reindexer instance correctly and resets memory pointer
-
-        #### Raises:
-            ConnectionError: Raises with an error message when Reindexer instance is not initialized yet
-
-        """
-
-        self.raise_on_not_init()
-        self.api.destroy(self.rx)
-        self.rx = 0
 
     def close(self) -> None:
         """Closes the API instance and frees Reindexer resources
@@ -508,9 +460,7 @@ class RxConnector(RaiserMixin):
         milliseconds: int = int(timeout / timedelta(milliseconds=1))
         self.err_code, self.err_msg, wrapper_ptr, iter_count, total_count = self.api.exec_sql(self.rx, query,
                                                                                               milliseconds)
-        return QueryResults(self, wrapper_ptr, iter_count, total_count)
-
-    ##### TRANSACTIONS
+        return QueryResults(self.api, wrapper_ptr, iter_count, total_count)
 
     @raise_if_error
     def new_transaction(self, namespace: str, timeout: timedelta = timedelta(milliseconds=0)) -> Transaction:
@@ -535,36 +485,9 @@ class RxConnector(RaiserMixin):
         milliseconds: int = int(timeout / timedelta(milliseconds=1))
         self.err_code, self.err_msg, transaction_wrapper_ptr = self.api.new_transaction(self.rx, namespace,
                                                                                         milliseconds)
-        return Transaction(self, transaction_wrapper_ptr)
-
-    def _tx_insert(self, tx_ptr: int, item_def: Dict, precepts: List[str]):
-        return self.api.item_insert_transaction(tx_ptr, item_def, precepts)
-
-    def _tx_update(self, tx_ptr: int, item_def: Dict, precepts: List[str]):
-        return self.api.item_update_transaction(tx_ptr, item_def, precepts)
-
-    def _tx_update_query(self, tx_ptr: int, query: Query):
-        return self.api.modify_transaction(tx_ptr, query.query_wrapper_ptr)
-
-    def _tx_upsert(self, tx_ptr: int, item_def: Dict, precepts: List[str]):
-        return self.api.item_upsert_transaction(tx_ptr, item_def, precepts)
-
-    def _tx_delete(self, tx_ptr: int, item_def: Dict):
-        return self.api.item_delete_transaction(tx_ptr, item_def)
-
-    def _tx_delete_query(self, tx_ptr: int, query: Query):
-        return self.api.delete_transaction(tx_ptr, query.query_wrapper_ptr)
-
-    def _tx_commit(self, tx_ptr: int, timeout: int):
-        return self.api.commit_transaction(tx_ptr, timeout)
-
-    def _tx_commit_with_count(self, tx_ptr: int, timeout: int):
-        return self.api.commit_transaction(tx_ptr, timeout)
-
-    def _tx_rollback(self, tx_ptr: int, timeout: int):
-        return self.api.rollback_transaction(tx_ptr, timeout)
-
-    ##### QUERY
+        transaction = Transaction(self.api, transaction_wrapper_ptr)
+        self.rx_objects.append(transaction)
+        return transaction
 
     @raise_if_error
     def new_query(self, namespace: str) -> Query:
@@ -582,4 +505,56 @@ class RxConnector(RaiserMixin):
         """
 
         self.err_code, self.err_msg, query_wrapper_ptr = self.api.create_query(self.rx, namespace)
-        return Query(self.api, query_wrapper_ptr)
+        query = Query(self.api, query_wrapper_ptr)
+        self.rx_objects.append(query)
+        return query
+
+    def _api_import(self, dsn: str) -> None:
+        """Imports an API dynamically depending on protocol specified in dsn
+
+        #### Arguments:
+            dsn (string): The connection string which contains a protocol
+
+        #### Raises:
+            ConnectionError: Raises an exception if a connection protocol is unrecognized
+
+        """
+
+        if dsn.startswith('builtin://'):
+            self.api = __import__('rawpyreindexerb')
+        elif dsn.startswith('cproto://'):
+            self.api = __import__('rawpyreindexerc')
+        else:
+            raise ConnectionError(f"Unknown Reindexer connection protocol for dsn: {dsn}")
+
+    def _api_connect(self, dsn: str, timeout: timedelta) -> None:
+        """Connects to a database specified in dsn. Obtains a pointer to Reindexer instance
+
+        #### Arguments:
+            dsn (string): The connection string which contains a protocol
+            timeout (`datetime.timedelta`): Optional timeout for performing a server-side operation.
+                Minimum is 1 millisecond; if set to a lower value, it corresponds to disabling the timeout.
+                A value of 0 disables the timeout (default value)
+
+        #### Raises:
+            ConnectionError: Raises with an error message when Reindexer instance is not initialized yet
+            ApiError: Raises with an error message of API return on non-zero error code
+
+        """
+
+        self.raise_on_not_init()
+        milliseconds: int = int(timeout / timedelta(milliseconds=1))
+        self.err_code, self.err_msg = self.api.connect(self.rx, dsn, milliseconds)
+        self.raise_on_error()
+
+    def _api_close(self) -> None:
+        """Destructs Reindexer instance correctly and resets memory pointer
+
+        #### Raises:
+            ConnectionError: Raises with an error message when Reindexer instance is not initialized yet
+
+        """
+
+        self.raise_on_not_init()
+        self.api.destroy(self.rx)
+        self.rx = 0

--- a/pyreindexer/transaction.py
+++ b/pyreindexer/transaction.py
@@ -40,7 +40,8 @@ class Transaction(RaiserTx):
             self.rollback(timedelta(milliseconds=0))
 
     def __finalize(self):
-        self.rx.tx_ptrs.remove(self.transaction_wrapper_ptr)
+        with self.rx._tx_lock:
+            self.rx._tx_ptrs.remove(self.transaction_wrapper_ptr)
         self.transaction_wrapper_ptr = 0
 
     @RaiserTx.raise_if_error

--- a/pyreindexer/transaction.py
+++ b/pyreindexer/transaction.py
@@ -26,7 +26,7 @@ class Transaction:
 
     """
 
-    def __init__(self, rx, transaction_wrapper_ptr: int):
+    def __init__(self, api, transaction_wrapper_ptr: int):
         """Constructs a new Reindexer transaction object
 
         #### Arguments:
@@ -35,7 +35,7 @@ class Transaction:
 
         """
 
-        self.rx = rx
+        self.api = api
         self.transaction_wrapper_ptr: int = transaction_wrapper_ptr
         self.err_code: int = 0
         self.err_msg: str = ""
@@ -46,8 +46,8 @@ class Transaction:
         """
 
         if self.transaction_wrapper_ptr > 0:
-            print("TX")
-            self.rollback(timedelta(milliseconds=0))
+            self.api.rollback_transaction(self.transaction_wrapper_ptr, 0)
+            self.transaction_wrapper_ptr = 0
 
     def _raise_on_error(self):
         """Checks if there is an error code and raises with an error message
@@ -87,7 +87,7 @@ class Transaction:
         """
 
         precepts = [] if precepts is None else precepts
-        self.err_code, self.err_msg = self.rx._tx_insert(self.transaction_wrapper_ptr, item_def, precepts)
+        self.err_code, self.err_msg = self.api.item_insert_transaction(self.transaction_wrapper_ptr, item_def, precepts)
 
     @raise_if_error
     def update(self, item_def: Dict, precepts: List[str] = None) -> None:
@@ -105,7 +105,7 @@ class Transaction:
         """
 
         precepts = [] if precepts is None else precepts
-        self.err_code, self.err_msg = self.rx._tx_update(self.transaction_wrapper_ptr, item_def, precepts)
+        self.err_code, self.err_msg = self.api.item_update_transaction(self.transaction_wrapper_ptr, item_def, precepts)
 
     @raise_if_error
     def update_query(self, query: Query) -> None:
@@ -122,7 +122,7 @@ class Transaction:
 
         """
 
-        self.err_code, self.err_msg = self.rx._tx_update_query(self.transaction_wrapper_ptr, query.query_wrapper_ptr)
+        self.err_code, self.err_msg = self.api.modify_transaction(self.transaction_wrapper_ptr, query.query_wrapper_ptr)
 
     @raise_if_error
     def upsert(self, item_def: Dict, precepts: List[str] = None) -> None:
@@ -140,7 +140,7 @@ class Transaction:
         """
 
         precepts = [] if precepts is None else precepts
-        self.err_code, self.err_msg = self.rx._tx_upsert(self.transaction_wrapper_ptr, item_def, precepts)
+        self.err_code, self.err_msg = self.api.item_upsert_transaction(self.transaction_wrapper_ptr, item_def, precepts)
 
     @raise_if_error
     def delete(self, item_def: Dict) -> None:
@@ -156,10 +156,10 @@ class Transaction:
 
         """
 
-        self.err_code, self.err_msg = self.rx._tx_delete(self.transaction_wrapper_ptr, item_def)
+        self.err_code, self.err_msg = self.api.item_delete_transaction(self.transaction_wrapper_ptr, item_def)
 
     @raise_if_error
-    def delete_query(self, query: Query) -> None:
+    def delete_query(self, query: Query):
         """Deletes items with the transaction
             Read-committed isolation is available for read operations.
             Changes made in active transaction is invisible to current and another transactions.
@@ -173,7 +173,7 @@ class Transaction:
 
         """
 
-        self.err_code, self.err_msg = self.rx._tx_delete_query(self.transaction_wrapper_ptr, query.query_wrapper_ptr)
+        self.err_code, self.err_msg = self.api.delete_transaction(self.transaction_wrapper_ptr, query.query_wrapper_ptr)
 
     @raise_if_error
     def commit(self, timeout: timedelta = timedelta(milliseconds=0)) -> None:
@@ -191,7 +191,7 @@ class Transaction:
         """
 
         milliseconds: int = int(timeout / timedelta(milliseconds=1))
-        self.err_code, self.err_msg, _ = self.rx._tx_commit(self.transaction_wrapper_ptr, milliseconds)
+        self.err_code, self.err_msg, _ = self.api.commit_transaction(self.transaction_wrapper_ptr, milliseconds)
         self.transaction_wrapper_ptr = 0
 
     @raise_if_error
@@ -210,7 +210,7 @@ class Transaction:
         """
 
         milliseconds: int = int(timeout / timedelta(milliseconds=1))
-        self.err_code, self.err_msg, count = self.rx._tx_commit_with_count(self.transaction_wrapper_ptr, milliseconds)
+        self.err_code, self.err_msg, count = self.api.commit_transaction(self.transaction_wrapper_ptr, milliseconds)
         self.transaction_wrapper_ptr = 0
         return count
 
@@ -230,5 +230,5 @@ class Transaction:
         """
 
         milliseconds: int = int(timeout / timedelta(milliseconds=1))
-        self.err_code, self.err_msg = self.rx._tx_rollback(self.transaction_wrapper_ptr, milliseconds)
+        self.err_code, self.err_msg = self.api.rollback_transaction(self.transaction_wrapper_ptr, milliseconds)
         self.transaction_wrapper_ptr = 0

--- a/pyreindexer/transaction.py
+++ b/pyreindexer/transaction.py
@@ -40,13 +40,14 @@ class Transaction:
         self.err_code: int = 0
         self.err_msg: str = ""
 
-    def _del(self):
+    def __del__(self):
         """Rollbacks a transaction if it was not previously stopped
 
         """
 
         if self.transaction_wrapper_ptr > 0:
             self.api.rollback_transaction(self.transaction_wrapper_ptr, 0)
+            self.transaction_wrapper_ptr = 0
 
     def _raise_on_error(self):
         """Checks if there is an error code and raises with an error message

--- a/pyreindexer/transaction.py
+++ b/pyreindexer/transaction.py
@@ -1,21 +1,11 @@
 from datetime import timedelta
 from typing import Dict, List
 
-from pyreindexer.exceptions import ApiError, TransactionError
 from pyreindexer.query import Query
+from raiser_mixin import RaiserTx
 
 
-def raise_if_error(func):
-    def wrapper(self, *args, **kwargs):
-        self._raise_on_is_over()
-        res = func(self, *args, **kwargs)
-        self._raise_on_error()
-        return res
-
-    return wrapper
-
-
-class Transaction:
+class Transaction(RaiserTx):
     """An object representing the context of a Reindexer transaction
 
     #### Attributes:
@@ -26,7 +16,7 @@ class Transaction:
 
     """
 
-    def __init__(self, api, transaction_wrapper_ptr: int):
+    def __init__(self, rx, transaction_wrapper_ptr: int):
         """Constructs a new Reindexer transaction object
 
         #### Arguments:
@@ -35,7 +25,8 @@ class Transaction:
 
         """
 
-        self.api = api
+        self.rx = rx
+        self.api = rx.api
         self.transaction_wrapper_ptr: int = transaction_wrapper_ptr
         self.err_code: int = 0
         self.err_msg: str = ""
@@ -45,33 +36,14 @@ class Transaction:
 
         """
 
-        if self.transaction_wrapper_ptr > 0:
-            self.api.rollback_transaction(self.transaction_wrapper_ptr, 0)
-            self.transaction_wrapper_ptr = 0
+        if self.transaction_wrapper_ptr > 0 and self.rx.rx > 0:
+            self.rollback(timedelta(milliseconds=0))
 
-    def _raise_on_error(self):
-        """Checks if there is an error code and raises with an error message
+    def __finalize(self):
+        self.rx.tx_ptrs.remove(self.transaction_wrapper_ptr)
+        self.transaction_wrapper_ptr = 0
 
-        #### Raises:
-            ApiError: Raises with an error message of API return on non-zero error code
-
-        """
-
-        if self.err_code:
-            raise ApiError(self.err_msg)
-
-    def _raise_on_is_over(self):
-        """Checks the state of a transaction and returns an error message when necessary
-
-        #### Raises:
-            TransactionError: Raises with an error message of API return if Transaction is over
-
-        """
-
-        if self.transaction_wrapper_ptr <= 0:
-            raise TransactionError("Transaction is over")
-
-    @raise_if_error
+    @RaiserTx.raise_if_error
     def insert(self, item_def: Dict, precepts: List[str] = None) -> None:
         """Inserts an item with its precepts to the transaction
             Warning: the timeout set when the transaction was created is used
@@ -87,9 +59,10 @@ class Transaction:
         """
 
         precepts = [] if precepts is None else precepts
-        self.err_code, self.err_msg = self.api.item_insert_transaction(self.transaction_wrapper_ptr, item_def, precepts)
+        self.err_code, self.err_msg = self.api.item_insert_transaction(self.transaction_wrapper_ptr,
+                                                                       item_def, precepts)
 
-    @raise_if_error
+    @RaiserTx.raise_if_error
     def update(self, item_def: Dict, precepts: List[str] = None) -> None:
         """Updates an item with its precepts to the transaction
             Warning: the timeout set when the transaction was created is used
@@ -105,9 +78,10 @@ class Transaction:
         """
 
         precepts = [] if precepts is None else precepts
-        self.err_code, self.err_msg = self.api.item_update_transaction(self.transaction_wrapper_ptr, item_def, precepts)
+        self.err_code, self.err_msg = self.api.item_update_transaction(self.transaction_wrapper_ptr,
+                                                                       item_def, precepts)
 
-    @raise_if_error
+    @RaiserTx.raise_if_error
     def update_query(self, query: Query) -> None:
         """Updates items with the transaction
             Read-committed isolation is available for read operations.
@@ -122,9 +96,10 @@ class Transaction:
 
         """
 
-        self.err_code, self.err_msg = self.api.modify_transaction(self.transaction_wrapper_ptr, query.query_wrapper_ptr)
+        self.err_code, self.err_msg = self.api.modify_transaction(self.transaction_wrapper_ptr,
+                                                                  query.query_wrapper_ptr)
 
-    @raise_if_error
+    @RaiserTx.raise_if_error
     def upsert(self, item_def: Dict, precepts: List[str] = None) -> None:
         """Updates an item with its precepts to the transaction. Creates the item if it does not exist
             Warning: the timeout set when the transaction was created is used
@@ -140,9 +115,10 @@ class Transaction:
         """
 
         precepts = [] if precepts is None else precepts
-        self.err_code, self.err_msg = self.api.item_upsert_transaction(self.transaction_wrapper_ptr, item_def, precepts)
+        self.err_code, self.err_msg = self.api.item_upsert_transaction(self.transaction_wrapper_ptr,
+                                                                       item_def, precepts)
 
-    @raise_if_error
+    @RaiserTx.raise_if_error
     def delete(self, item_def: Dict) -> None:
         """Deletes an item from the transaction
             Warning: the timeout set when the transaction was created is used
@@ -156,9 +132,10 @@ class Transaction:
 
         """
 
-        self.err_code, self.err_msg = self.api.item_delete_transaction(self.transaction_wrapper_ptr, item_def)
+        self.err_code, self.err_msg = self.api.item_delete_transaction(self.transaction_wrapper_ptr,
+                                                                       item_def)
 
-    @raise_if_error
+    @RaiserTx.raise_if_error
     def delete_query(self, query: Query):
         """Deletes items with the transaction
             Read-committed isolation is available for read operations.
@@ -173,9 +150,10 @@ class Transaction:
 
         """
 
-        self.err_code, self.err_msg = self.api.delete_transaction(self.transaction_wrapper_ptr, query.query_wrapper_ptr)
+        self.err_code, self.err_msg = self.api.delete_transaction(self.transaction_wrapper_ptr,
+                                                                  query.query_wrapper_ptr)
 
-    @raise_if_error
+    @RaiserTx.raise_if_error
     def commit(self, timeout: timedelta = timedelta(milliseconds=0)) -> None:
         """Applies changes
 
@@ -191,10 +169,11 @@ class Transaction:
         """
 
         milliseconds: int = int(timeout / timedelta(milliseconds=1))
-        self.err_code, self.err_msg, _ = self.api.commit_transaction(self.transaction_wrapper_ptr, milliseconds)
-        self.transaction_wrapper_ptr = 0
+        self.err_code, self.err_msg, _ = self.api.commit_transaction(self.transaction_wrapper_ptr,
+                                                                     milliseconds)
+        self.__finalize()
 
-    @raise_if_error
+    @RaiserTx.raise_if_error
     def commit_with_count(self, timeout: timedelta = timedelta(milliseconds=0)) -> int:
         """Applies changes and return the number of count of changed items
 
@@ -210,11 +189,12 @@ class Transaction:
         """
 
         milliseconds: int = int(timeout / timedelta(milliseconds=1))
-        self.err_code, self.err_msg, count = self.api.commit_transaction(self.transaction_wrapper_ptr, milliseconds)
-        self.transaction_wrapper_ptr = 0
+        self.err_code, self.err_msg, count = self.api.commit_transaction(self.transaction_wrapper_ptr,
+                                                                         milliseconds)
+        self.__finalize()
         return count
 
-    @raise_if_error
+    @RaiserTx.raise_if_error
     def rollback(self, timeout: timedelta = timedelta(milliseconds=0)) -> None:
         """Rollbacks changes
 
@@ -230,5 +210,6 @@ class Transaction:
         """
 
         milliseconds: int = int(timeout / timedelta(milliseconds=1))
-        self.err_code, self.err_msg = self.api.rollback_transaction(self.transaction_wrapper_ptr, milliseconds)
-        self.transaction_wrapper_ptr = 0
+        self.err_code, self.err_msg = self.api.rollback_transaction(self.transaction_wrapper_ptr,
+                                                                    milliseconds)
+        self.__finalize()

--- a/pyreindexer/transaction.py
+++ b/pyreindexer/transaction.py
@@ -40,13 +40,13 @@ class Transaction:
         self.err_code: int = 0
         self.err_msg: str = ""
 
-    def __del__(self):
+    def _del(self):
         """Rollbacks a transaction if it was not previously stopped
 
         """
 
         if self.transaction_wrapper_ptr > 0:
-            _, _ = self.api.rollback_transaction(self.transaction_wrapper_ptr)
+            self.api.rollback_transaction(self.transaction_wrapper_ptr, 0)
 
     def _raise_on_error(self):
         """Checks if there is an error code and raises with an error message

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ with open('README.md', 'r', encoding='utf-8') as file:
     LONG_DESCRIPTION = file.read()
 
 setup(name=PACKAGE_NAME,
-      version='0.5.90001',
+      version='0.5.90002',
       description='A connector that allows to interact with Reindexer. Reindexer static library or reindexer-dev package must be installed',
       author='Igor Tulmentyev',
       author_email='contactus@reindexer.io',

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ with open('README.md', 'r', encoding='utf-8') as file:
     LONG_DESCRIPTION = file.read()
 
 setup(name=PACKAGE_NAME,
-      version='0.5.90002',
+      version='0.5.90003',
       description='A connector that allows to interact with Reindexer. Reindexer static library or reindexer-dev package must be installed',
       author='Igor Tulmentyev',
       author_email='contactus@reindexer.io',


### PR DESCRIPTION
Fixed:
- missed timeout arg in `__del__` method for tx rollback
- rx, transaction and query `__del__` methods did not have a consistent operation order